### PR TITLE
Fixes #11 -- Split artist and title on first delimiter

### DIFF
--- a/src/Adapter/Icecast.php
+++ b/src/Adapter/Icecast.php
@@ -99,8 +99,7 @@ final class Icecast extends AdapterAbstract
             $np->currentSong = new CurrentSong(
                 $row['yp_currently_playing'] ?? '',
                 $row['title'] ?? '',
-                $row['artist'] ?? '',
-                ' - '
+                $row['artist'] ?? ''
             );
 
             $bitrate = $row['audio_bitrate'] ?? $row['bitrate'] ?? null;
@@ -176,8 +175,7 @@ final class Icecast extends AdapterAbstract
         $np->currentSong = new CurrentSong(
             '',
             $title,
-            $artist,
-            ' - '
+            $artist
         );
 
         $bitrate = max(

--- a/src/Adapter/Shoutcast1.php
+++ b/src/Adapter/Shoutcast1.php
@@ -37,7 +37,10 @@ final class Shoutcast1 extends AdapterAbstract
 
         // Increment listener counts in the now playing data.
         $np = new Result;
-        $np->currentSong = new CurrentSong($title);
+        $np->currentSong = new CurrentSong(
+            text: $title,
+            delimiter: '-'
+        );
         $np->listeners = new Listeners((int)$total_listeners, (int)$unique_listeners);
         $np->meta = new Meta(
             !empty($np->currentSong->text),

--- a/src/Adapter/Shoutcast2.php
+++ b/src/Adapter/Shoutcast2.php
@@ -88,7 +88,10 @@ final class Shoutcast2 extends AdapterAbstract
         $currentSongText = str_replace('   ', ' - ', $currentSongText);
 
         $np = new Result;
-        $np->currentSong = new CurrentSong($currentSongText);
+        $np->currentSong = new CurrentSong(
+            text: $currentSongText,
+            delimiter: '-'
+        );
         $np->listeners = new Listeners(
             (int)$xml->CURRENTLISTENERS,
             (int)$xml->UNIQUELISTENERS

--- a/src/Result/CurrentSong.php
+++ b/src/Result/CurrentSong.php
@@ -16,7 +16,7 @@ final class CurrentSong
         string $text = '',
         string $title = '',
         string $artist = '',
-        string $delimiter = '-'
+        string $delimiter = ' - '
     ) {
         $text = $this->cleanUpString($text);
         $title = $this->cleanUpString($title);
@@ -35,8 +35,8 @@ final class CurrentSong
             if (\count($string_parts) === 1) {
                 $title = $text;
             } else {
-                $title = trim(array_pop($string_parts));
-                $artist = trim(implode($delimiter, $string_parts));
+                $title = trim(implode($delimiter, array_slice($string_parts, 1)));
+                $artist = trim($string_parts[0]);
             }
         }
 


### PR DESCRIPTION
Split artist and title correctly when there are multiple delimiters. I have also added spaces around the delimiter to avoid splitting artists with hyphenated names in the wrong place.

**Fixes issue:**
#11